### PR TITLE
added footer option on SignInScreen.

### DIFF
--- a/packages/flutter_firebase_ui/lib/flutter_firebase_ui.dart
+++ b/packages/flutter_firebase_ui/lib/flutter_firebase_ui.dart
@@ -11,12 +11,14 @@ class SignInScreen extends StatefulWidget {
     Key key,
     this.title,
     this.header,
+    this.footer,
     this.providers,
     this.color = Colors.white,
   }) : super(key: key);
 
   final String title;
   final Widget header;
+  final Widget footer;
   final List<ProvidersTypes> providers;
   final Color color;
 
@@ -26,6 +28,7 @@ class SignInScreen extends StatefulWidget {
 
 class _SignInScreenState extends State<SignInScreen> {
   Widget get _header => widget.header ?? new Container();
+  Widget get _footer => widget.footer ?? new Container();
 
   List<ProvidersTypes> get _providers =>
       widget.providers ?? [ProvidersTypes.email];
@@ -46,6 +49,7 @@ class _SignInScreenState extends State<SignInScreen> {
                 children: <Widget>[
                   _header,
                   new Expanded(child: new LoginView(providers: _providers)),
+                  _footer
                 ],
               ));
         },


### PR DESCRIPTION
Header was already there, so why not footer?
with this, you can for example show a privacy policy agreement text before login, like this:
<br>

<img src="https://user-images.githubusercontent.com/24274639/44215523-08750d80-a173-11e8-98e7-ffbb87155e3b.png" width="400">