### PR TITLE
added optional password confirmation at mail creat

### DIFF
--- a/packages/flutter_firebase_ui/lib/email_view.dart
+++ b/packages/flutter_firebase_ui/lib/email_view.dart
@@ -7,6 +7,10 @@ import 'sign_up_view.dart';
 import 'utils.dart';
 
 class EmailView extends StatefulWidget {
+  final bool passwordCheck;
+
+  EmailView(this.passwordCheck, {Key key}) : super(key: key);
+
   @override
   _EmailViewState createState() => new _EmailViewState();
 }
@@ -66,7 +70,7 @@ class _EmailViewState extends State<EmailView> {
         bool connected = await Navigator
             .of(context)
             .push(new MaterialPageRoute<bool>(builder: (BuildContext context) {
-          return new SignUpView(_controllerEmail.text);
+          return new SignUpView(_controllerEmail.text, widget.passwordCheck);
         }));
 
         if (connected) {

--- a/packages/flutter_firebase_ui/lib/flutter_firebase_ui.dart
+++ b/packages/flutter_firebase_ui/lib/flutter_firebase_ui.dart
@@ -12,6 +12,7 @@ class SignInScreen extends StatefulWidget {
     this.title,
     this.header,
     this.footer,
+    this.signUpPasswordCheck,
     this.providers,
     this.color = Colors.white,
   }) : super(key: key);
@@ -21,6 +22,7 @@ class SignInScreen extends StatefulWidget {
   final Widget footer;
   final List<ProvidersTypes> providers;
   final Color color;
+  final bool signUpPasswordCheck;
 
   @override
   _SignInScreenState createState() => new _SignInScreenState();
@@ -29,6 +31,8 @@ class SignInScreen extends StatefulWidget {
 class _SignInScreenState extends State<SignInScreen> {
   Widget get _header => widget.header ?? new Container();
   Widget get _footer => widget.footer ?? new Container();
+
+  bool get _passwordCheck => widget.signUpPasswordCheck ?? false;
 
   List<ProvidersTypes> get _providers =>
       widget.providers ?? [ProvidersTypes.email];
@@ -48,7 +52,10 @@ class _SignInScreenState extends State<SignInScreen> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
                   _header,
-                  new Expanded(child: new LoginView(providers: _providers)),
+                  new Expanded(
+                      child: new LoginView(
+                          providers: _providers,
+                          passwordCheck: _passwordCheck)),
                   _footer
                 ],
               ));

--- a/packages/flutter_firebase_ui/lib/l10n/localization.dart
+++ b/packages/flutter_firebase_ui/lib/l10n/localization.dart
@@ -21,6 +21,8 @@ class FFULocalizations {
   String get cancelButtonLabel => _translationBundle.cancelButtonLabel;
 
   String get passwordLabel => _translationBundle.passwordLabel;
+  String get passwordCheckLabel => _translationBundle.passwordCheckLabel;
+  String get passwordCheckError => _translationBundle.passwordCheckError;
 
   String get troubleSigningInLabel => _translationBundle.troubleSigningInLabel;
 

--- a/packages/flutter_firebase_ui/lib/l10n/translations.dart
+++ b/packages/flutter_firebase_ui/lib/l10n/translations.dart
@@ -14,6 +14,10 @@ class TranslationBundle {
 
   String get passwordLabel => parent?.passwordLabel;
 
+  String get passwordCheckLabel => parent?.passwordCheckLabel;
+
+  String get passwordCheckError => parent?.passwordCheckError;
+
   String get troubleSigningInLabel => parent?.troubleSigningInLabel;
 
   String get signInLabel => parent?.signInLabel;
@@ -56,6 +60,12 @@ class _Bundle_fr extends TranslationBundle {
   String get emailLabel => r'Adresse mail';
   @override
   String get passwordLabel => r'Mot de passe';
+
+  @override
+  String get passwordCheckLabel => r'Confirmez le mot de passe';
+
+  @override
+  String get passwordCheckError => r'Les deux mots de passe sont différents.';
 
   @override
   String get nextButtonLabel => r'SUIVANT';
@@ -131,6 +141,12 @@ class _Bundle_en extends TranslationBundle {
   String get passwordLabel => r'Password';
 
   @override
+  String get passwordCheckLabel => r'Confirm the password';
+
+  @override
+  String get passwordCheckError => r'The two passwords are different';
+
+  @override
   String get nextButtonLabel => r'NEXT';
   @override
   String get cancelButtonLabel => r'CANCEL';
@@ -200,6 +216,12 @@ class _Bundle_de extends TranslationBundle {
   String get emailLabel => r'Email';
   @override
   String get passwordLabel => r'Passwort';
+
+  @override
+  String get passwordCheckLabel => r'Bestätigen Sie das Passwort';
+
+  @override
+  String get passwordCheckError => r'Die zwei Passwörter sind unterschiedlich';
 
   @override
   String get nextButtonLabel => r'WEITER';

--- a/packages/flutter_firebase_ui/lib/login_view.dart
+++ b/packages/flutter_firebase_ui/lib/login_view.dart
@@ -9,10 +9,12 @@ import 'utils.dart';
 
 class LoginView extends StatefulWidget {
   final List<ProvidersTypes> providers;
+  final bool passwordCheck;
 
   LoginView({
     Key key,
     @required this.providers,
+    this.passwordCheck,
   }) : super(key: key);
 
   @override
@@ -28,7 +30,7 @@ class _LoginViewState extends State<LoginView> {
     String value = await Navigator
         .of(context)
         .push(new MaterialPageRoute<String>(builder: (BuildContext context) {
-      return new EmailView();
+      return new EmailView(widget.passwordCheck);
     }));
 
     if (value != null) {

--- a/packages/flutter_firebase_ui/lib/sign_up_view.dart
+++ b/packages/flutter_firebase_ui/lib/sign_up_view.dart
@@ -7,8 +7,9 @@ import 'utils.dart';
 
 class SignUpView extends StatefulWidget {
   final String email;
+  final bool passwordCheck;
 
-  SignUpView(this.email, {Key key}) : super(key: key);
+  SignUpView(this.email, this.passwordCheck, {Key key}) : super(key: key);
 
   @override
   _SignUpViewState createState() => new _SignUpViewState();
@@ -18,6 +19,7 @@ class _SignUpViewState extends State<SignUpView> {
   TextEditingController _controllerEmail;
   TextEditingController _controllerDisplayName;
   TextEditingController _controllerPassword;
+  TextEditingController _controllerCheckPassword;
 
   bool _valid = false;
 
@@ -27,6 +29,7 @@ class _SignUpViewState extends State<SignUpView> {
     _controllerEmail = new TextEditingController(text: widget.email);
     _controllerDisplayName = new TextEditingController();
     _controllerPassword = new TextEditingController();
+    _controllerCheckPassword = new TextEditingController();
   }
 
   @override
@@ -41,7 +44,7 @@ class _SignUpViewState extends State<SignUpView> {
         builder: (BuildContext context) {
           return new Padding(
             padding: const EdgeInsets.all(16.0),
-            child: new Column(
+            child: new ListView(
               children: <Widget>[
                 new TextField(
                   controller: _controllerEmail,
@@ -67,6 +70,17 @@ class _SignUpViewState extends State<SignUpView> {
                   decoration: new InputDecoration(
                       labelText: FFULocalizations.of(context).passwordLabel),
                 ),
+                !widget.passwordCheck
+                    ? new Container()
+                    : new TextField(
+                        controller: _controllerCheckPassword,
+                        obscureText: true,
+                        autocorrect: false,
+                        decoration: new InputDecoration(
+                            labelText: FFULocalizations
+                                .of(context)
+                                .passwordCheckLabel),
+                      ),
               ],
             ),
           );
@@ -91,6 +105,12 @@ class _SignUpViewState extends State<SignUpView> {
   }
 
   _connexion(BuildContext context) async {
+    if (widget.passwordCheck &&
+        _controllerPassword.text != _controllerCheckPassword.text) {
+      showErrorDialog(context, FFULocalizations.of(context).passwordCheckError);
+      return;
+    }
+
     FirebaseAuth _auth = FirebaseAuth.instance;
     try {
       await _auth.createUserWithEmailAndPassword(


### PR DESCRIPTION
adds a field at account creation with email which asks to retype the password to confirm it.
If the two password fields are differents, an error message pops up,
and the ```_connexion``` method is left.

this option is activated at SignInScreen creation,
with optional boolean parameter signUpPasswordCheck
(defaults to false, leaving the UI like it was before)

added 2 locale strings for "Confirm password" and "Passwords are
incorrect" messages.
I am not sure of the German translation, as I created it with Google Translate...

Screenshots:
<img src="https://user-images.githubusercontent.com/24274639/44577296-01608780-a791-11e8-93ac-8a1526cfb528.jpg"  height="250"/>

<img src="https://user-images.githubusercontent.com/24274639/44575963-ae390580-a78d-11e8-9f02-b2c474d03f45.jpg" height="150" />
